### PR TITLE
Fixed amd64 docker files.

### DIFF
--- a/IoTEdgeModbus/Modules/AzureIoTEdgeModbus/Dockerfile.amd64
+++ b/IoTEdgeModbus/Modules/AzureIoTEdgeModbus/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk AS build-env
+FROM microsoft/dotnet:2.2-sdk AS build-env
 WORKDIR /app
 
 COPY *.csproj ./
@@ -15,9 +15,9 @@ COPY *.c ./
 COPY *.h ./
 
 # build
-RUN gcc -shared -o libcomWrapper.so -fPIC comWrapper.c
+RUN gcc -shared -o libcomWrapper.so -fPIC ComWrapper.c
 
-FROM microsoft/dotnet:2.1-runtime
+FROM microsoft/dotnet:2.2-runtime
 WORKDIR /app
 COPY --from=build-env /app/out ./
 COPY --from=build-env-2 /app/libcomWrapper.so /usr/lib/
@@ -25,4 +25,4 @@ COPY --from=build-env-2 /app/libcomWrapper.so /usr/lib/
 RUN useradd -ms /bin/bash moduleuser
 USER moduleuser
 
-ENTRYPOINT ["dotnet", "iotedgeModbus.dll"]
+ENTRYPOINT ["dotnet", "AzureIoTEdgeModbus.dll"]

--- a/IoTEdgeModbus/Modules/AzureIoTEdgeModbus/Dockerfile.amd64.debug
+++ b/IoTEdgeModbus/Modules/AzureIoTEdgeModbus/Dockerfile.amd64.debug
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0-runtime-stretch AS base
+FROM microsoft/dotnet:2.2-runtime-stretch AS base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends unzip procps && \
@@ -8,7 +8,7 @@ RUN useradd -ms /bin/bash moduleuser
 USER moduleuser
 RUN curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l ~/vsdbg
 
-FROM microsoft/dotnet:2.1-sdk AS build-env
+FROM microsoft/dotnet:2.2-sdk AS build-env
 WORKDIR /app
 
 COPY *.csproj ./
@@ -25,11 +25,11 @@ COPY *.c ./
 COPY *.h ./
 
 # build
-RUN gcc -shared -o libcomWrapper.so -fPIC comWrapper.c
+RUN gcc -shared -o libcomWrapper.so -fPIC ComWrapper.c
 
 FROM base
 WORKDIR /app
 COPY --from=build-env /app/out ./
 COPY --from=build-env-2 /app/libcomWrapper.so /usr/lib/
 
-ENTRYPOINT ["dotnet", "iotedgeModbus.dll"]
+ENTRYPOINT ["dotnet", "AzureIoTEdgeModbus.dll"]


### PR DESCRIPTION
Fixed amd64 docker files to be able to build and push from within Visual Studio 2019 (to private repository).